### PR TITLE
Added feature of survey ownership

### DIFF
--- a/src/app/components/edit-survey/edit-survey.component.ts
+++ b/src/app/components/edit-survey/edit-survey.component.ts
@@ -5,6 +5,7 @@ import { NzNotificationService } from 'ng-zorro-antd/notification';
 import { Survey } from 'src/app/model/Survey';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { serverTimestamp } from 'firebase/firestore';
+import { AuthService } from 'src/app/service/auth.service';
 
 @Component({
   selector: 'app-edit-survey',
@@ -23,6 +24,7 @@ export class EditSurveyComponent {
     private fb: FormBuilder,
     private modalRef: NzModalRef,
     private notification: NzNotificationService,
+    private auth: AuthService,
   ) { }
 
   ngOnInit(): void {
@@ -67,6 +69,7 @@ export class EditSurveyComponent {
             title: this.form?.value.title?.trim(),
             desc: this.form?.value.desc?.trim(),
             isPublished: this.form?.value.isPublished,
+            ownerId: this.auth.user?.uid,
             questions: this.form?.value.questions.map((question: any) => ({
               label: question.label?.trim(),
               type: question.type?.trim(),

--- a/src/app/components/view-survey/view-survey.component.ts
+++ b/src/app/components/view-survey/view-survey.component.ts
@@ -6,6 +6,7 @@ import { NzNotificationService } from 'ng-zorro-antd/notification';
 import { NzModalRef } from 'ng-zorro-antd/modal';
 import { Result } from 'src/app/model/Result';
 import { DatePipe } from '@angular/common';
+import { AuthService } from 'src/app/service/auth.service';
 
 @Component({
   selector: 'app-view-survey',
@@ -22,12 +23,14 @@ export class ViewSurveyComponent implements OnInit {
     private modalRef: NzModalRef,
     private notification: NzNotificationService,
     private afs: AngularFirestore,
+    private auth : AuthService
   ) {
 
   }
 
   ngOnInit(): void {
-    if (this.survey?.id) {
+    const currentUserId = this.auth.user?.uid;
+    if (currentUserId && this.survey?.id) {
       this.results$ = this.afs.collection<Result>("results", ref => ref.where("surveyId", "==", this.survey?.id).orderBy("createdTime", "desc"))
         .snapshotChanges()
         .pipe(

--- a/src/app/model/Survey.ts
+++ b/src/app/model/Survey.ts
@@ -10,6 +10,7 @@ export interface Survey {
     required: boolean;
   }[];
   isPublished: boolean;
+  ownerId : String;
   createdTime: firebase.firestore.Timestamp;
   updatedTime: firebase.firestore.Timestamp;
 }


### PR DESCRIPTION
Added `ownerId` to the survey model which stores the Firebase user id of the user who creates the survey.
Modified the `edit-survey` component to store the uid during survey creation.
Modified the dashboard page so that only surveys belonging to the logged-in user are shown.
Modified the `view-survey` component accordingly.